### PR TITLE
Handle all Croc DE strats

### DIFF
--- a/assemble.py
+++ b/assemble.py
@@ -41,12 +41,20 @@ def main(input, output):
 	# Print out label physical locations
 	print()
 	print("*" * 80)
-	print("STRUN.BIN/croc.db might need to be updated, if you have modified the strat in such a way that the entry point addresses have changed.")
+	print("STRUN.BIN/croc.db might need to be updated, if you have modified the strat in such a way that the entry point addresses or numbers of used global variables have changed.")
 	print("To update croc.db (for Definitive Edition) you need to open croc.db at table StratIndex in database browsing software and run the following:")
 	print()
 	
+	failed_strats = []
 	for s in strat_info:
-		print(f"UPDATE StratIndex SET pc = {labels[strat_info[s]['pc']] - 4} WHERE name = '{strat_info[s]['name']}';")
+		if strat_info[s]['pc'] in labels:
+			print(f"UPDATE StratIndex SET pc = {labels[strat_info[s]['pc']] - 4}, var_size = {strat_info[s]['vars']} WHERE name = '{strat_info[s]['name']}';")
+		else:
+			failed_strats.append(strat_info[s]['name'])
+
+	if len(failed_strats) > 0:
+		print()
+		print("WARNING!!!: No matching labels for strats: " + ", ".join(failed_strats))
 	
 	print()
 	print("Right now there is no way to edit STRUN.BIN unless you have a hexeditor and know the format.")

--- a/check_diff.py
+++ b/check_diff.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python
+"""
+Compare two compiled strats and check for difference
+"""
+
+import sys
+from stratigise.common import BinaryReadStream
+
+def check_diff(strat1_path, strat2_path):
+    strat1 = BinaryReadStream(strat1_path)
+    strat2 = BinaryReadStream(strat2_path)
+
+    size1 = strat1.readInt32LE()
+    entry1 = strat1.readInt16LE()
+    axx_start1 = strat1.readInt16LE() + 4
+	
+    size2 = strat2.readInt32LE()
+    entry2 = strat2.readInt16LE()
+    axx_start2 = strat2.readInt16LE() + 4
+
+    if entry1 != entry2:
+        print(f"Entry mismatch: {hex(entry1)} != {hex(entry2)}")
+
+    axx1, str_locs1, preloads1 = read_axx(strat1, axx_start1)
+    axx2, str_locs2, preloads2 = read_axx(strat2, axx_start2)
+
+    if preloads1 != preloads2:
+        print("Preloads mismatch:")
+        print("1: ", preloads1)
+        print("2: ", preloads2)
+
+    # There is one case when one string is missing from the initial strat
+    if len(axx1) != len(axx2) and len(axx1) + 1 != len(axx2):
+        print(f"AXX entry counts mismatch: {len(axx1)} != {len(axx2)}")
+        print("AXX 1: ", axx1)
+        print("AXX 2: ", axx2)
+    else:
+        for i in range(len(axx1)):
+            if axx1[i]["kind"] != axx2[i]["kind"]:
+                print(f"AXX entries mismatch at index {i}: {axx1[i]} != {axx2[i]}")
+                print("AXX 1: ", axx1)
+                print("AXX 2: ", axx2)
+                break
+    
+    strat1.setPos(8)
+    strat2.setPos(8)
+
+    prev = []
+
+    while True:
+        pos1 = strat1.getPos()
+        pos2 = strat2.getPos()
+
+        if pos1 in str_locs1 and pos2 in str_locs2:
+            string1 = read_string(strat1)
+            string2 = read_string(strat2)
+
+            if string1 != string2:
+                print(f"Code mismatch: string `{string1}` vs string `{string2}` at {hex(pos1)} - {hex(pos2)}")
+                break
+
+        elif pos1 not in str_locs1 and pos2 not in str_locs2:
+            byte1 = strat1.readInt8()
+            byte2 = strat2.readInt8()
+
+            if byte1 != byte2:
+                # Handling special cases
+
+                # Spawn* + old-fashioned 32-bit placeholder vk. 64-bit one
+                if len(prev) >= 5 and prev[-5] in [0x30, 0x77, 0xb1] and prev[-4:] == [0, 0, 0, 0]:
+                    bytes = strat2.readBytes(3)
+                    if byte2 == 0 and bytes == b"\x00\x00\x00":
+                        strat1.setPos(strat1.getPos() - 1)
+                        continue
+
+                    strat2.setPos(strat2.getPos() - 3)
+
+                # CreateTrigger 1 Label + 4 extra zero bytes
+                if len(prev) >= 4 and prev[-4] == 0x31 and prev[-3] == 1:
+                    bytes = strat1.readBytes(3)
+                    if byte1 == 0 and bytes == b"\x00\x00\x00":
+                        strat2.setPos(strat2.getPos() - 1)
+                        continue
+
+                    strat1.setPos(strat1.getPos() - 3)
+
+                # Wrong opcode for PushPGVar
+                if byte1 == 0x1b and byte2 == 0x1:
+                    continue
+
+                # Maybe these are labels - let's check what they're pointing at is
+                byte12 = strat1.readInt8()
+                byte22 = strat2.readInt8()
+                label1 = byte1 + 256 * byte12
+                label2 = byte2 + 256 * byte22
+
+                op1 = read_byte_at(strat1, strat1.getPos() + label1)
+                op2 = read_byte_at(strat2, strat2.getPos() + label2)
+
+                if op1 is not None and op1 == op2:
+                    prev.append(byte1)
+                    prev.append(byte12)
+                    continue
+
+                op1 = read_byte_at(strat1, label1 + 4)
+                op2 = read_byte_at(strat2, label2 + 4)
+
+                if op1 is not None and op1 == op2:
+                    prev.append(byte1)
+                    prev.append(byte12)
+                    continue
+
+                strat1.setPos(strat1.getPos() - 1)
+                strat2.setPos(strat2.getPos() - 1)
+
+                print(f"Code mismatch: byte {hex(byte1)} vs byte {hex(byte2)} at {hex(pos1)} - {hex(pos2)}")
+                break
+
+            if byte1 == 0x3b:
+                break
+
+            prev.append(byte1)
+
+        elif pos1 in str_locs1:
+            print(f"Code mismatch: string `{read_string(strat1)}` vs byte {hex(strat2.readInt8())} at {hex(pos1)} - {hex(pos2)}")
+            break
+
+        else:
+            string2 = read_string(strat2)
+
+            sz = strat1.readInt8()
+
+            # Case when string isn't presented in original AXX
+            if sz == len(string2) or sz == len(string2) + 1:
+                strat1.setPos(strat1.getPos() - 1)
+                string1 = read_string(strat1)
+
+                if string1 != string2:
+                    print(f"Code mismatch: string `{string1}` vs string `{string2}` at {hex(pos1)} - {hex(pos2)}")
+                    break
+            else:
+                print(f"Code mismatch: byte {hex(sz)} vs string `{string2}` at {hex(pos1)} - {hex(pos2)}")
+                break
+
+def read_axx(strat, start):
+    strat.setPos(start)
+
+    count = strat.readInt16LE()
+    axx = []
+    str_locs = []
+    preloads = []
+
+    for i in range(count):
+        kind = strat.readInt8()
+        if kind == 0:
+            string = read_string(strat)
+            if string not in preloads:
+                preloads.append(string)
+        else:
+            location = strat.readInt16LE()
+            axx.append({"kind": kind, "location": location})
+            str_locs.append(location + 4)
+
+    return axx, str_locs, sorted(preloads)
+
+def read_byte_at(strat, pos):
+    if pos < 0 or pos >= strat.getLength():
+        return None
+
+    cur_pos = strat.getPos()
+    strat.setPos(pos)
+
+    byte = strat.readInt8()
+
+    strat.setPos(cur_pos)
+
+    return byte
+
+def read_string(strat):
+    sz = strat.readInt8()
+    if sz is None:
+        return "<EOF>"
+    elif sz > 0:
+        return strat.readBytes(sz).decode('latin-1').replace('\x00', '')
+    else:
+        return ""
+
+if (__name__ == "__main__"):
+    if (len(sys.argv) == 3):
+        check_diff(sys.argv[1], sys.argv[2])
+    else:
+        print(f"Usage: {sys.argv[0]} <strat file> <strat file>")

--- a/specs/croc1/health_check.py
+++ b/specs/croc1/health_check.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python
+"""
+Run disasembler, reconstructor and compiler for all strats
+"""
+
+import sys, os, shutil, subprocess, re
+
+KNOWN_BROKEN = [
+    "BIRDSHLD.BIN", # Broken header
+    "BLKNT_A3.BIN", # Empty
+    "BMANTEST.BIN", # Empty
+    "BUBBGEN.BIN", # Broken header
+    "CORC.BIN", # Empty
+    "FADETEST.BIN", # Empty
+    "FLIBBY1.BIN", # Empty
+    "MVSNPLAT.BIN", # Empty
+    "MVSNWPLT.BIN", # Empty
+    "MVSNWQT3.BIN", # Empty
+    "PLATPETE.BIN", # Empty
+    "SEED2.BIN", # Empty
+    "SNAPPY.BIN", # Empty
+    "SPIN.BIN", # Empty
+    "ROLBOL0.BIN", # Broken header
+    "TARPLAT.BIN", # Broken header
+    "TIMESWCH.BIN", # Broken header
+
+    # "BRAT1.BIN", # There are some zeros after valid `CreateTrigger 1 Label`
+    # "FIRSTAT.BIN", # Weird PlayerIsWithinRadius2D call on empty stack
+    # "FRST.BIN", # Weird PlayerIsWithinRadius2D call on empty stack
+    # "RDFL.BIN", # There are some zeros after valid `CreateTrigger 1 Label`
+    # "RKMO1.BIN", # Incompatible 32-bit placeholders instead of 64-bit
+    # "TWST1.BIN", # Weird PlayerIsWithinRadius2D call on empty stack
+    # "TWST2.BIN", # Weird PlayerIsWithinRadius2D call on empty stack
+    # "SHFN.BIN", # Incompatible 32-bit placeholders instead of 64-bit
+    # "SMASHBLK.BIN", # Incompatible 32-bit placeholders instead of 64-bit
+    # "SMOKIE.BIN", # There are some zeros after valid `CreateTrigger 1 Label`
+    # "UPEXIT.BIN" # Some weird 0xfd after valid `UnpausePlayer`
+]
+
+def full_run(strats_dir, csv_path, output_dir):
+    if not os.path.isdir(strats_dir):
+        raise Exception(f"{strats_dir} is not a directory")
+    if not os.path.isdir(output_dir):
+        raise Exception(f"{output_dir} is not a directory")
+    if not os.path.isfile(csv_path):
+        raise Exception(f"{csv_path} doesn't exist")
+    
+    items = os.listdir(strats_dir)
+    strats = []
+    for item in items:
+        if item[-4:] == ".BIN" and os.path.isfile(os.path.join(strats_dir, item)):
+            strats.append(item)
+
+    print_fixed("STRAT", 15)
+    print_fixed("DISASM", 12)
+    print_fixed("ASM", 12)
+    print("DIFF")
+
+    counts = {
+        "disassembler": {"success": 0, "warning": 0, "failed": 0},
+        "assembler": {"success": 0, "warning": 0, "failed": 0},
+        "diff": {"success": 0, "warning": 0, "failed": 0},
+        "reconstructor": {"success": 0, "warning": 0, "failed": 0},
+        "compiler": {"success": 0, "warning": 0, "failed": 0},
+        "ignored": 0
+    }
+
+    for strat in strats:
+        run_strat(strat, os.path.join(strats_dir, strat), csv_path, os.path.join(output_dir, strat[:-4]), counts)
+
+    print("")
+    print_fixed("STAGE", 20)
+    print_fixed("OK", 10)
+    print_fixed("WARNING", 10)
+    print_fixed("FAILED", 10)
+    print_fixed("SKIPPED", 10)
+    print("SCORE")
+
+    total = len(strats) - counts["ignored"]
+
+    for stage in ["disassembler", "assembler", "diff"]:
+        print_fixed(stage, 20)
+        print_fixed(counts[stage]["success"], 10)
+        print_fixed(counts[stage]["warning"], 10)
+        print_fixed(counts[stage]["failed"], 10)
+        print_fixed(total - counts[stage]["success"] - counts[stage]["warning"] - counts[stage]["failed"], 10)
+
+        success = counts[stage]["success"] + counts[stage]["warning"] / 2.0
+        percentage = success / float(total) * 100.0
+        print(f"{percentage:.1f}%")
+    
+    print(f"\nIgnored {counts['ignored']} strat files")
+
+def run_strat(strat, strat_path, csv_path, output_dir, counts):
+    print_fixed(strat, 15)
+
+    if strat in KNOWN_BROKEN:
+        print("Known broken -- ignored")
+        counts["ignored"] += 1
+        return
+
+    if not os.path.isdir(output_dir):
+        os.mkdir(output_dir)
+
+    strat_bin = os.path.join(output_dir, strat)
+    shutil.copy(strat_path, output_dir)
+    shutil.copy(csv_path, output_dir)
+
+    bin_dir = os.path.dirname(sys.argv[0])
+
+    # Disasm
+
+    cmd = ["python", os.path.join(bin_dir, '..', '..', 'disassemble.py'), strat_bin]
+
+    try:
+        result = subprocess.run(cmd, capture_output = True, encoding = "utf-8", env={'PYTHONIOENCODING': 'utf-8'}, timeout=1)
+    except subprocess.TimeoutExpired:
+        print("Timeout!")
+        counts["disassembler"]["failed"] += 1
+        return
+
+    os.remove(os.path.join(output_dir, os.path.basename(csv_path)))
+
+    with open(os.path.join(output_dir, f"{strat}.disassembler.out"), "w", encoding = "utf-8") as f:
+        f.write(result.stdout)
+    with open(os.path.join(output_dir, f"{strat}.disassembler.err"), "w", encoding = "utf-8") as f:
+        f.write(result.stderr)
+
+    if result.returncode != 0:
+        print("Failed!")
+        counts["disassembler"]["failed"] += 1
+        return
+    
+    mo = re.search("Found (\d+) strat\(s\) in", result.stdout)
+    if not mo:
+        print("Invalid output!")
+        counts["reconstructor"]["failed"] += 1
+        return
+    #if int(mo.group(1)) == 0:
+    #    print("No strats -- ignored")
+    #    counts["ignored"] += 1
+    #    return
+    
+    strat_disasm = strat_bin + ".DIS"
+    
+    errors = 0
+    with open(strat_disasm) as f:
+        text = f.read()
+        errors += text.count("CommandError")
+        errors += text.count("__unknown_operation_0x")
+
+    if errors > 0:
+        print_fixed(f"{errors} errors", 12)
+        counts["disassembler"]["warning"] += 1
+    else:
+        print_fixed("OK", 12)
+        counts["disassembler"]["success"] += 1
+
+    # Assembler
+
+    strat_reasm = strat_bin[:-4] + ".reassembled.BIN"
+    
+    cmd = ["python", os.path.join(bin_dir, '..', '..', 'assemble.py'), strat_disasm, strat_reasm]
+
+    try:
+        result = subprocess.run(cmd, capture_output = True, encoding = "utf-8", env={'PYTHONIOENCODING': 'utf-8'}, timeout=1)
+    except subprocess.TimeoutExpired:
+        print("Timeout!")
+        counts["assembler"]["failed"] += 1
+        return
+
+    with open(os.path.join(output_dir, f"{strat}.assembler.out"), "w", encoding = "utf-8") as f:
+        f.write(result.stdout)
+    with open(os.path.join(output_dir, f"{strat}.assembler.err"), "w", encoding = "utf-8") as f:
+        f.write(result.stderr)
+
+    if result.returncode != 0:
+        print("Failed!")
+        counts["assembler"]["failed"] += 1
+        return
+    
+    print_fixed("OK", 12)
+    counts["assembler"]["success"] += 1
+    
+    # Difference check
+    
+    cmd = ["python", os.path.join(bin_dir, '..', '..', 'check_diff.py'), strat_bin, strat_reasm]
+
+    try:
+        result = subprocess.run(cmd, capture_output = True, encoding = "utf-8", env={'PYTHONIOENCODING': 'utf-8'}, timeout=1)
+    except subprocess.TimeoutExpired:
+        print("Timeout!")
+        counts["diff"]["failed"] += 1
+        return
+
+    with open(os.path.join(output_dir, f"{strat}.check_diff.out"), "w", encoding = "utf-8") as f:
+        f.write(result.stdout)
+    with open(os.path.join(output_dir, f"{strat}.check_diff.err"), "w", encoding = "utf-8") as f:
+        f.write(result.stderr)
+
+    if result.returncode != 0:
+        print("Failed!")
+        counts["diff"]["failed"] += 1
+        return
+
+    if result.stdout != "":
+        print("Mismatch!")
+        counts["diff"]["failed"] += 1
+        return
+
+    counts["diff"]["success"] += 1
+    print("OK")
+
+def print_fixed(string, width):
+    s = str(string)
+    print(s + " " * (width - len(s)), end = "")
+
+if (__name__ == "__main__"):
+    if (len(sys.argv) == 4):
+        full_run(sys.argv[1], sys.argv[2], sys.argv[3])
+    else:
+        print(f"Usage: {sys.argv[0]} <strats dir> <csv path> <output dir>")


### PR DESCRIPTION
This PR makes possible to disassemble and reassemble all of Croc DE strats except several broken ones (empty or having invalid header). Also some additional tools are introduced.

<img width="480" alt="Скриншот 2024-06-06 22 03 11" src="https://github.com/Argonaut-PS1-Reverse/Stratigise/assets/5449928/b14d7773-37dd-425d-94f9-52f09d37049d">


Asm changes:
- some signature fixes according to decompiled Croc code
- handling of the rest of AXX entries types, including the 'preloading' one
- some flexibility to handle several incompatible strats (probably some old versions)

Tools:
- `specs/croc1/check_diff.py` - a tool to compare original BIN with reassembled one and find discrepancies
- `health_check.py` - runs disasm/asm/diff check against all strats in the directory and collects stats and logs